### PR TITLE
Doc: Fixed a typo in the Program.fs open statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See the [SingleCounter](https://github.com/elmish/Elmish.WPF/tree/master/src/Sam
 
    ```F#
    open System
-   open Elmish
+   open Elmish.WPF
    
    [<EntryPoint; STAThread>]
    let main argv =


### PR DESCRIPTION
This tripped me up when I was trying to get started and didn't want others to have the same initial experience.